### PR TITLE
pc - add javadoc to SecurityConfig.java

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -35,6 +35,10 @@ import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class defines the security configuration for the application.
+ */
+
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)


### PR DESCRIPTION
This PR adds some javadoc to the file SecurityConfig.java, but it's primary purpose is to test the 
docs workflows for PRs